### PR TITLE
[Enhance76] 리스트아이템 동작과 구분 추가

### DIFF
--- a/src/pages/board/ListItem.jsx
+++ b/src/pages/board/ListItem.jsx
@@ -16,39 +16,12 @@ ListItem.propTypes = {
       category: PropTypes.array.isRequired,
       tags: PropTypes.array.isRequired,
       due: PropTypes.string.isRequired,
+      productState: PropTypes.string.isRequired,
     }),
   }),
 };
 
 // 남은 시간 계산하는 헬퍼 함수
-// function calculateRemainingTime(due) {
-//   const now = moment(); // 현재 시각
-//   const dueTime = moment(due, "YYYY.MM.DD HH:mm:ss"); // 마감일시를 moment 객체로 변환
-//   const diff = dueTime.diff(now); // 남은 시간 (밀리초 단위)
-
-//   if (diff <= 0) {
-//     return "마감";
-//   }
-
-//   // 남은 시간 계산
-//   const duration = moment.duration(diff); // moment의 duration 사용
-//   const days = Math.floor(duration.asDays()); // 남은 일수
-//   const hours = duration.hours(); // 남은 시간
-//   const minutes = duration.minutes(); // 남은 분
-
-//   // 남은 시간에 따라 다른 텍스트 반환
-//   if (days > 0) {
-//     // 1일 이상 남았을 때
-//     return `${days}일 남음`;
-//   } else if (hours > 0) {
-//     // 1일 미만, 시간 단위로 남았을 때
-//     return `${hours}시간 남음`;
-//   } else if (minutes > 0) {
-//     // 1시간 미만으로 남았을 때
-//     return "곧 마감";
-//   }
-// }
-
 function calculateRemainingTime(due) {
   const now = dayjs(); // 현재 시각
   const dueTime = dayjs(due, "YYYY.MM.DD HH:mm:ss"); // 마감일시를 dayjs 객체로 변환
@@ -78,6 +51,17 @@ function calculateRemainingTime(due) {
 }
 
 export default function ListItem({ item }) {
+  // 심부름 상태 변수
+  const isCompleted = item.extra?.productState[0] === "PS030";
+  const isExpired = item.extra?.productState[0] === "PS040";
+  // const listItemColor = isCompleted || isExpired ? "bg-gray-300" : "bg-white";
+
+  // 완료 또는 만료된 심부름에 덮을 반투명 레이어
+  const overlayClass =
+    isCompleted || isExpired
+      ? "absolute inset-0 bg-gray-400 opacity-50 rounded-[10px]"
+      : "";
+
   // category에 따라 이미지 경로 매핑
   const categoryImages = {
     PC01: "/assets/bike.svg",
@@ -97,8 +81,9 @@ export default function ListItem({ item }) {
   return (
     <Link
       to={`/errand/${item._id}`}
-      className="list_item w-full h-[116px] rounded-[10px] bg-[#fff] shadow-card-shadow px-[22px] py-[18px] flex gap-[24px] items-center"
+      className={`list_item w-full h-[116px] rounded-[10px] bg-white shadow-card-shadow px-[22px] py-[18px] flex gap-[24px] items-center relative`}
     >
+      <div className={`overlay ${overlayClass}`}></div>
       <img
         src={categoryImage}
         alt="게시글 대표이미지"
@@ -110,7 +95,7 @@ export default function ListItem({ item }) {
           {item.name}
         </h2>
 
-        <TagList tags={item.extra?.tags} />
+        <TagList item={item} />
 
         <div className="li_info flex flex-grow justify-between">
           <div className="font-pretendard text-card-timelimit">

--- a/src/pages/board/ListItem.jsx
+++ b/src/pages/board/ListItem.jsx
@@ -48,6 +48,7 @@ ListItem.propTypes = {
 //     return "곧 마감";
 //   }
 // }
+
 function calculateRemainingTime(due) {
   const now = dayjs(); // 현재 시각
   const dueTime = dayjs(due, "YYYY.MM.DD HH:mm:ss"); // 마감일시를 dayjs 객체로 변환
@@ -65,10 +66,13 @@ function calculateRemainingTime(due) {
   };
 
   if (duration.days > 0) {
+    // 하루 이상 남은 경우
     return `${duration.days}일 남음`;
   } else if (duration.hours > 0) {
+    // 하루 미만, 1시간 이상 남은 경우
     return `${duration.hours}시간 남음`;
   } else if (duration.minutes > 0) {
+    // 1시간 미만으로 남은 경우
     return "곧 마감";
   }
 }
@@ -91,7 +95,10 @@ export default function ListItem({ item }) {
   const remainingTime = calculateRemainingTime(item.extra?.due);
 
   return (
-    <li className="list_item w-full h-[116px] rounded-[10px] bg-[#fff] shadow-card-shadow px-[22px] py-[18px] flex gap-[24px] items-center">
+    <Link
+      to={`/errand/${item._id}`}
+      className="list_item w-full h-[116px] rounded-[10px] bg-[#fff] shadow-card-shadow px-[22px] py-[18px] flex gap-[24px] items-center"
+    >
       <img
         src={categoryImage}
         alt="게시글 대표이미지"
@@ -100,12 +107,7 @@ export default function ListItem({ item }) {
 
       <div className="li_contents max-w-full min-w-0 flex flex-col flex-grow gap-[4px]">
         <h2 className="li_title font-laundry text-card-title truncate overflow-hidden text-ellipsis">
-          <Link
-            to={`/products/${item._id}`}
-            state={{ back: "/products", title: "심부름 상세" }} // 업데이트 된 방식 props 추가
-          >
-            {item.name}
-          </Link>
+          {item.name}
         </h2>
 
         <TagList tags={item.extra?.tags} />
@@ -114,9 +116,11 @@ export default function ListItem({ item }) {
           <div className="font-pretendard text-card-timelimit">
             {remainingTime}
           </div>
-          <div className="font-pretendard text-card-price">{item.price} 원</div>
+          <div className="font-pretendard text-card-price">
+            {new Intl.NumberFormat("ko-KR").format(item.price)} 원
+          </div>
         </div>
       </div>
-    </li>
+    </Link>
   );
 }

--- a/src/pages/board/ListItem.jsx
+++ b/src/pages/board/ListItem.jsx
@@ -94,7 +94,7 @@ export default function ListItem({ item }) {
       <div
         className={`overlay ${overlayClass} flex items-center justify-center`}
       >
-        <p className="w-1/2 h-1/2 bg-white bg-opacity-70 flex items-center justify-center rounded-lg font-laundry text-[20px] text-gray-700">
+        <p className="w-1/2 h-1/2 bg-white bg-opacity-70 flex items-center justify-center rounded-lg font-laundry text-[20px] text-gray-500">
           {overlayMessage}
         </p>
       </div>

--- a/src/pages/board/ListItem.jsx
+++ b/src/pages/board/ListItem.jsx
@@ -16,7 +16,7 @@ ListItem.propTypes = {
       category: PropTypes.array.isRequired,
       tags: PropTypes.array.isRequired,
       due: PropTypes.string.isRequired,
-      productState: PropTypes.string.isRequired,
+      productState: PropTypes.array.isRequired,
     }),
   }),
 };
@@ -59,8 +59,16 @@ export default function ListItem({ item }) {
   // 완료 또는 만료된 심부름에 덮을 반투명 레이어
   const overlayClass =
     isCompleted || isExpired
-      ? "absolute inset-0 bg-gray-400 opacity-50 rounded-[10px]"
+      ? "absolute inset-0 bg-gray-400 bg-opacity-50 rounded-[10px]"
       : "";
+
+  // 반투명 레이어에 띄울 메시지
+  let overlayMessage;
+  if (isCompleted) {
+    overlayMessage = "완료된 심부름";
+  } else if (isExpired) {
+    overlayMessage = "기한이 지난 심부름";
+  }
 
   // category에 따라 이미지 경로 매핑
   const categoryImages = {
@@ -83,7 +91,13 @@ export default function ListItem({ item }) {
       to={`/errand/${item._id}`}
       className={`list_item w-full h-[116px] rounded-[10px] bg-white shadow-card-shadow px-[22px] py-[18px] flex gap-[24px] items-center relative`}
     >
-      <div className={`overlay ${overlayClass}`}></div>
+      <div
+        className={`overlay ${overlayClass} flex items-center justify-center`}
+      >
+        <p className="w-1/2 h-1/2 bg-white bg-opacity-70 flex items-center justify-center rounded-lg font-laundry text-[20px] text-gray-700">
+          {overlayMessage}
+        </p>
+      </div>
       <img
         src={categoryImage}
         alt="게시글 대표이미지"

--- a/src/pages/board/TagList.jsx
+++ b/src/pages/board/TagList.jsx
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types";
 
 TagList.propTypes = {
-  tags: PropTypes.array.isRequired,
+  item: PropTypes.object.isRequired,
 };
 
-export default function TagList({ tags }) {
+export default function TagList({ item }) {
   // 태그 별로 이미지와 텍스트 매핑
   const tagData = {
     TA01: {
@@ -45,9 +45,11 @@ export default function TagList({ tags }) {
   };
 
   return (
-    <ul className="tags flex gap-[8px] min-w-0 w-full overflow-scroll scrollbar-hide">
-      {tags?.length > 0 ? (
-        tags.map((tag, index) => {
+    <ul
+      className={`tags flex gap-[8px] min-w-0 w-full overflow-scroll scrollbar-hide`}
+    >
+      {item.extra?.tags.length > 0 ? (
+        item.extra?.tags.map((tag, index) => {
           const tagInfo = tagData[tag] || {}; // 태그 정보 가져오기
 
           return (

--- a/src/pages/board/TagList.jsx
+++ b/src/pages/board/TagList.jsx
@@ -45,7 +45,7 @@ export default function TagList({ tags }) {
   };
 
   return (
-    <ul className="tags flex gap-[8px] min-w-0 w-full overflow-scroll">
+    <ul className="tags flex gap-[8px] min-w-0 w-full overflow-scroll scrollbar-hide">
       {tags?.length > 0 ? (
         tags.map((tag, index) => {
           const tagInfo = tagData[tag] || {}; // 태그 정보 가져오기

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -18,11 +18,8 @@ const router = createBrowserRouter(
       // errorElement: <ErrorPage />,
       children: [
         { index: true, element: <MainPage /> },
-        { path: "products/:_id", element: <Detail /> },
-        { path: "products/new", element: <New /> },
-        // { path: ":type", element: <List /> },
-        // { path: ":type/new", element: <New /> },
-        // { path: ":type/:_id/edit", element: <Edit /> },
+        { path: "errand/:_id", element: <Detail /> },
+        { path: "errand/new", element: <New /> },
         { path: "users/signup", element: <Signup /> },
         { path: "users/login", element: <Login /> },
         { path: "users/mypage", element: <MyPage /> },


### PR DESCRIPTION
## 🔍 PR 유형 (Type of PR)

어떤 변경사항인지 체크해주세요 (중복 체크 가능):

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 🎨 CSS 등 사용자 UI 디자인 변경
- [ ] 🗃 데이터베이스 관련 작업
- [ ] ➕ 라이브러리 및 의존성 추가
- [ ] ➖ 라이브러리 및 의존성 제거
- [ ] 📝 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️ 코드 리팩토링
- [ ] 💬 주석 추가 및 수정
- [ ] 📄 문서 수정
- [ ] 🧪 테스트 추가, 테스트 리팩토링
- [ ] 📦 빌드 또는 패키지 매니저 수정
- [ ] 🗂️ 파일 혹은 폴더 추가/이름 수정
- [ ] 🗑️ 파일 혹은 폴더 삭제

---

## 📝 PR 설명 (Description)

- [x] 상세보기 페이지로 이동하는 링크 추가
- [x] 배경색상 동적 렌더링: 기본 / 완료/ 기간만료
  - [x] 태그리스트 영역 배경색도 같이 변경
- [x] 배경색상 동적 렌더링 대신, 완료 또는 만료 심부름에는 회색 오버레이 덮어서 처리
- [x] '완료된 심부름' 또는 '기한이 지난 심부름' 문구 표시되는 오버레이 하나 더 추가
- [x] UI 개선
  - [x] 금액 숫자 세 자리씩 끊어서 표시 (화면 상으로만)
  - [x] 태그리스트 스크롤바 숨기기

---

## 🔗 관련 이슈 (Related Issues)

- #76 

---

## 📸 스크린샷 (Screenshots)

<img width="440" alt="Screenshot 2025-01-13 at 14 21 36" src="https://github.com/user-attachments/assets/b269ac0f-eac9-4438-81e2-91a5e7880ad8" />

- 완료 / 기간만료 심부름은 모두 회색 오버레이로 덮었습니다.
- 그 위에 반투명 박스요소를 하나 추가하여 완료된 심부름 / 기한이 지난 심부름 문구를 표시했습니다.

---

## ✅ 체크리스트 (Checklist)

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 **컴파일**되고 모든 **테스트**를 통과했습니다.
- [x] 필요한 경우 **주석**을 작성했습니다.
- [ ] 관련 **문서**를 업데이트했습니다.

---

## 🛠 추가 정보 (Additional Information)

- 추가로 공유할 내용이 있으면 여기에 작성해주세요.
